### PR TITLE
Add Map method to Series to support function application over Series

### DIFF
--- a/series/series.go
+++ b/series/series.go
@@ -85,6 +85,8 @@ func (e boolElements) Elem(i int) Element { return &e[i] }
 // unmarshaling Elements.
 type ElementValue interface{}
 
+type MapFunction func(Element) Element
+
 // Comparator is a convenience alias that can be used for a more type safe way of
 // reason and use comparators.
 type Comparator string
@@ -740,3 +742,19 @@ func (s Series) Quantile(p float64) float64 {
 
 	return stat.Quantile(p, stat.Empirical, ordered, nil)
 }
+
+// Map applies a function matching MapFunction signature, which itself 
+// allowing for a fairly flexible MAP implementation, intended for mapping
+// the function over each element in Series and returning a new Series object.
+// Function must be compatible with the underlying type of data in the Series.
+// In other words it is expected that when working with a Float Series, that
+// the function passed in via argument `f` will not expect another type, but
+// instead expects to handle Element(s) of type Float.
+func (s Series) Map(f MapFunction) Series {
+		
+	mappedValues := make([]Element, s.Len())
+	for i := 0; i < s.Len(); i++ {
+		value := f(s.elements.Elem(i))
+		mappedValues[i] = value
+	}
+	return New(mappedValues, s.Type(), s.Name)

--- a/series/series_test.go
+++ b/series/series_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"reflect"
 	"testing"
+	"strings"
 )
 
 // Check that there are no shared memory addreses between the elements of two Series
@@ -1466,6 +1467,144 @@ func TestSeries_Quantile(t *testing.T) {
 				"Test:%v\nExpected:\n%v\nReceived:\n%v",
 				testnum, expected, received,
 			)
+		}
+	}
+}
+
+
+func TestSeries_Map(t *testing.T) {
+		tests := []struct {
+		series   Series
+		expected Series
+	}{
+		{
+			Bools([]bool{false, true, false, false, true}),
+			Bools([]bool{false, true, false, false, true}),
+		},
+		{
+			Floats([]float64{1.5, -3.23, -0.337397, -0.380079, 1.60979, 34.}),
+			Floats([]float64{3, -6.46, -0.674794, -0.760158, 3.21958, 68.}),
+		},
+		{
+			Floats([]float64{math.Pi, math.Phi, math.SqrtE, math.Cbrt(64)}),
+			Floats([]float64{2 * math.Pi, 2 * math.Phi, 2 * math.SqrtE, 2 * math.Cbrt(64)}),
+		},
+		{
+			Strings([]string{"XyZApple", "XyZBanana", "XyZCitrus", "XyZDragonfruit"}),
+			Strings([]string{"Apple", "Banana", "Citrus", "Dragonfruit"}),
+		},
+		{
+			Strings([]string{"San Francisco", "XyZTokyo", "MoscowXyZ", "XyzSydney"}),
+			Strings([]string{"San Francisco", "Tokyo", "MoscowXyZ", "XyzSydney"}),
+		},
+		{
+			Ints([]int{23, 13, 101, -64, -3}),
+			Ints([]int{28, 18, 106, -59, 2}),
+		},
+		{
+			Ints([]string{"morning", "noon", "afternoon", "evening", "night"}),
+			Ints([]int{5, 5, 5, 5, 5}),
+		},
+	}
+
+	doubleFloat64 := func(e Element) Element {
+		var result Element
+		result = e.Copy()
+		result.Set(result.Float() * 2)		
+		return Element(result)
+	}
+
+	// and two booleans 
+	and := func(e Element) Element {
+		var result Element
+		result = e.Copy()
+		b, err := result.Bool()
+		if err != nil {
+			t.Errorf("%v", err)
+			return Element(nil)
+		}
+		result.Set(b && true)
+		return Element(result)
+	}
+
+	// add constant (+5) to value (v)
+	add5Int := func(e Element) Element {
+		var result Element
+		result = e.Copy()
+		i, err := result.Int()
+		if err != nil {
+			return Element(&intElement{
+				e: +5,
+				nan: false,
+			})
+		}
+		result.Set(i + 5)		
+		return Element(result)
+	}
+
+	// trim (XyZ) prefix from string
+	trimXyZPrefix := func(e Element) Element {
+		var result Element
+		result = e.Copy()
+		result.Set(strings.TrimPrefix(result.String(), "XyZ"))
+		return Element(result)
+	}
+
+		for testnum, test := range tests {
+		switch test.series.Type() {
+		case Bool:
+			expected := test.expected
+			received := test.series.Map(and)
+			for i := 0 ; i<expected.Len() ; i++ {
+				e, _ := expected.Elem(i).Bool()
+				r, _ := received.Elem(i).Bool()
+
+				if e != r {
+					t.Errorf(
+						"Test:%v\nExpected:\n%v\nReceived:\n%v",
+						testnum, expected, received,
+					)
+				}
+			}
+			
+		case Float:
+			expected := test.expected
+			received := test.series.Map(doubleFloat64)
+			for i := 0 ; i<expected.Len() ; i++ {
+				if !compareFloats(expected.Elem(i).Float(),
+				received.Elem(i).Float(), 6) {
+					t.Errorf(
+						"Test:%v\nExpected:\n%v\nReceived:\n%v",
+						testnum, expected, received,
+					)
+				}
+			}
+		case Int:
+			expected := test.expected
+			received := test.series.Map(add5Int)
+			for i := 0 ; i<expected.Len() ; i++ {
+				e, _ := expected.Elem(i).Int()
+				r, _ := received.Elem(i).Int()
+				if e != r {
+					t.Errorf(
+						"Test:%v\nExpected:\n%v\nReceived:\n%v",
+						testnum, expected, received,
+					)
+				}
+			}
+		case String:
+			expected := test.expected
+			received := test.series.Map(trimXyZPrefix)
+			for i :=0 ; i<expected.Len() ; i++ {
+				if strings.Compare(expected.Elem(i).String(),
+				received.Elem(i).String()) != 0 {
+					t.Errorf(
+						"Test:%v\nExpected:\n%v\nReceived:\n%v",
+						testnum, expected, received,
+					)
+				}
+			}
+		default:
 		}
 	}
 }


### PR DESCRIPTION
This is another try at Map method implementation. It seems substantially simpler, but expects more in some ways from the function being applied over the elements. Let me know if you feel this is acceptable and if not, what you might like to see changed, assuming this is still a worthwhile addition.

Thanks, Sam.