### PR TITLE
Correct the types of constants in blocks for Type and Comparator

### DIFF
--- a/series/series.go
+++ b/series/series.go
@@ -92,12 +92,12 @@ type Comparator string
 // Supported Comparators
 const (
 	Eq        Comparator = "==" // Equal
-	Neq                  = "!=" // Non equal
-	Greater              = ">"  // Greater than
-	GreaterEq            = ">=" // Greater or equal than
-	Less                 = "<"  // Lesser than
-	LessEq               = "<=" // Lesser or equal than
-	In                   = "in" // Inside
+	Neq       Comparator = "!=" // Non equal
+	Greater   Comparator = ">"  // Greater than
+	GreaterEq Comparator = ">=" // Greater or equal than
+	Less      Comparator = "<"  // Lesser than
+	LessEq    Comparator = "<=" // Lesser or equal than
+	In        Comparator = "in" // Inside
 )
 
 // Type is a convenience alias that can be used for a more type safe way of
@@ -107,9 +107,9 @@ type Type string
 // Supported Series Types
 const (
 	String Type = "string"
-	Int         = "int"
-	Float       = "float"
-	Bool        = "bool"
+	Int    Type = "int"
+	Float  Type = "float"
+	Bool   Type = "bool"
 )
 
 // Indexes represent the elements that can be used for selecting a subset of


### PR DESCRIPTION
The constant blocks for `Type` and `Comparator` correctly define the type of the first constant in the block as `Type` and `Comparator`, respectively, but the other constants are then automatically inferred as string or ints. This leads to issues when using the library with gophernotes. See `https://stackoverflow.com/questions/6937716/grouping-of-constants-in-go-language` for some discussion of enums in Go.

See the below example from the official Go documentation at `https://golang.org/ref/spec#Constant_declarations`:

```
const Pi float64 = 3.14159265358979323846
const zero = 0.0         // untyped floating-point constant
const (
	size int64 = 1024
	eof        = -1  // untyped integer constant
)
const a, b, c = 3, 4, "foo"  // a = 3, b = 4, c = "foo", untyped integer and string constants
const u, v float32 = 0, 3    // u = 0.0, v = 3.0
```

This pull request addresses this issue by ensuring that all constants within each block have the same type.