### PR TITLE
Replace imports of kniren/gota with go-gota/gota in tests.

### DIFF
--- a/dataframe/benchmark_test.go
+++ b/dataframe/benchmark_test.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/kniren/gota/dataframe"
-	"github.com/kniren/gota/series"
+	"github.com/go-gota/gota/dataframe"
+	"github.com/go-gota/gota/series"
 )
 
 func generateSeries(n, rep int) (data []series.Series) {

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -10,7 +10,7 @@ import (
 	"math"
 
 	"github.com/gonum/matrix/mat64"
-	"github.com/kniren/gota/series"
+	"github.com/go-gota/gota/series"
 )
 
 // compareFloats compares floating point values up to the number of digits specified.

--- a/dataframe/examples_test.go
+++ b/dataframe/examples_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kniren/gota/dataframe"
-	"github.com/kniren/gota/series"
+	"github.com/go-gota/gota/dataframe"
+	"github.com/go-gota/gota/series"
 )
 
 func ExampleNew() {

--- a/series/benchmarks_test.go
+++ b/series/benchmarks_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/kniren/gota/series"
+	"github.com/go-gota/gota/series"
 )
 
 func generateInts(n int) (data []int) {


### PR DESCRIPTION
The reference to github.com/kniren/gota is confusing go mod, resulting in errors like `cannot use "github.com/go-gota/gota/series".Eq (type "github.com/go-gota/gota/series".Comparator) as type "github.com/kniren/gota/series".Comparator in field value`. 