### PR TITLE
use go.mod, fix github paths, and fix failing tests (TestLoadRecords)

### DIFF
--- a/dataframe/benchmark_test.go
+++ b/dataframe/benchmark_test.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/kniren/gota/dataframe"
-	"github.com/kniren/gota/series"
+	"github.com/go-gota/gota/dataframe"
+	"github.com/go-gota/gota/series"
 )
 
 func generateSeries(n, rep int) (data []series.Series) {

--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -769,7 +769,6 @@ func WithComments(b rune) LoadOption {
 	}
 }
 
-
 // LoadStructs creates a new DataFrame from arbitrary struct slices.
 //
 // LoadStructs will ignore unexported fields inside an struct. Note also that
@@ -973,12 +972,12 @@ func LoadRecords(records [][]string, options ...LoadOption) DataFrame {
 
 		t, ok := cfg.types[colname]
 		if !ok {
-		  t = cfg.defaultType
-		  if cfg.detectTypes {
-		    if l, err := findType(rawcol); err != nil {
-		      t = l
-		    }
-		  }
+			t = cfg.defaultType
+			if cfg.detectTypes {
+				if l, err := findType(rawcol); err == nil {
+					t = l
+				}
+			}
 		}
 		types[i] = t
 	}
@@ -1867,17 +1866,20 @@ func findType(arr []string) (series.Type, error) {
 		}
 		hasStrings = true
 	}
+
+	fmt.Printf("float %t, int %t, bool %t, string %t\n", hasFloats, hasInts, hasBools, hasStrings)
+
 	switch {
 	case hasStrings:
-	  return series.String, nil
+		return series.String, nil
 	case hasBools:
-	  return series.Bool, nil
+		return series.Bool, nil
 	case hasFloats:
-	  return series.Float, nil
+		return series.Float, nil
 	case hasInts:
-	  return series.Int, nil
+		return series.Int, nil
 	default:
-	  return series.String, fmt.Errorf("couldn't detect type")
+		return series.String, fmt.Errorf("couldn't detect type")
 	}
 }
 

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -9,8 +9,8 @@ import (
 
 	"math"
 
+	"github.com/go-gota/gota/series"
 	"github.com/gonum/matrix/mat64"
-	"github.com/kniren/gota/series"
 )
 
 // compareFloats compares floating point values up to the number of digits specified.

--- a/dataframe/examples_test.go
+++ b/dataframe/examples_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kniren/gota/dataframe"
-	"github.com/kniren/gota/series"
+	"github.com/go-gota/gota/dataframe"
+	"github.com/go-gota/gota/series"
 )
 
 func ExampleNew() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/go-gota/gota
+
+go 1.12
+
+require (
+	github.com/gonum/blas v0.0.0-20181208220705-f22b278b28ac // indirect
+	github.com/gonum/floats v0.0.0-20181209220543-c233463c7e82 // indirect
+	github.com/gonum/integrate v0.0.0-20181209220457-a422b5c0fdf2 // indirect
+	github.com/gonum/internal v0.0.0-20181124074243-f884aa714029 // indirect
+	github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9 // indirect
+	github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9
+	github.com/gonum/stat v0.0.0-20181125101827-41a0da705a5b
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/gonum/blas v0.0.0-20181208220705-f22b278b28ac h1:Q0Jsdxl5jbxouNs1TQYt0gxesYMU4VXRbsTlgDloZ50=
+github.com/gonum/blas v0.0.0-20181208220705-f22b278b28ac/go.mod h1:P32wAyui1PQ58Oce/KYkOqQv8cVw1zAapXOl+dRFGbc=
+github.com/gonum/floats v0.0.0-20181209220543-c233463c7e82 h1:EvokxLQsaaQjcWVWSV38221VAK7qc2zhaO17bKys/18=
+github.com/gonum/floats v0.0.0-20181209220543-c233463c7e82/go.mod h1:PxC8OnwL11+aosOB5+iEPoV3picfs8tUpkVd0pDo+Kg=
+github.com/gonum/integrate v0.0.0-20181209220457-a422b5c0fdf2 h1:GUSkTcIe1SlregbHNUKbYDhBsS8lNgYfIp4S4cToUyU=
+github.com/gonum/integrate v0.0.0-20181209220457-a422b5c0fdf2/go.mod h1:pDgmNM6seYpwvPos3q+zxlXMsbve6mOIPucUnUOrI7Y=
+github.com/gonum/internal v0.0.0-20181124074243-f884aa714029 h1:8jtTdc+Nfj9AR+0soOeia9UZSvYBvETVHZrugUowJ7M=
+github.com/gonum/internal v0.0.0-20181124074243-f884aa714029/go.mod h1:Pu4dmpkhSyOzRwuXkOgAvijx4o+4YMUJJo9OvPYMkks=
+github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9 h1:7qnwS9+oeSiOIsiUMajT+0R7HR6hw5NegnKPmn/94oI=
+github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9/go.mod h1:XA3DeT6rxh2EAE789SSiSJNqxPaC0aE9J8NTOI0Jo/A=
+github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9 h1:V2IgdyerlBa/MxaEFRbV5juy/C3MGdj4ePi+g6ePIp4=
+github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9/go.mod h1:0EXg4mc1CNP0HCqCz+K4ts155PXIlUywf0wqN+GfPZw=
+github.com/gonum/stat v0.0.0-20181125101827-41a0da705a5b h1:fbskpz/cPqWH8VqkQ7LJghFkl2KPAiIFUHrTJ2O3RGk=
+github.com/gonum/stat v0.0.0-20181125101827-41a0da705a5b/go.mod h1:Z4GIJBJO3Wa4gD4vbwQxXXZ+WHmW6E9ixmNrwvs0iZs=

--- a/series/benchmarks_test.go
+++ b/series/benchmarks_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/kniren/gota/series"
+	"github.com/go-gota/gota/series"
 )
 
 func generateInts(n int) (data []int) {


### PR DESCRIPTION
Similar to #81 but only introduces go.mod, fixes the import paths to github.com/go-gota/..., and fixes a bug that led to TestLoadRecords failures (was introduced in 1058f871be3128db7c45dd188594e462cd417c5f).
