### PR TITLE
Add dataframe.Concat

### DIFF
--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -427,6 +427,54 @@ func (df DataFrame) RBind(dfb DataFrame) DataFrame {
 	return New(expandedSeries...)
 }
 
+// Concat concatenates rows of two DataFrames like RBind, but also including
+// unmatched columns.
+func (df DataFrame) Concat(dfb DataFrame) DataFrame {
+	if df.Err != nil {
+		return df
+	}
+	if dfb.Err != nil {
+		return dfb
+	}
+
+	uniques := make(map[string]struct{})
+	cols := []string{}
+	for _, t := range []DataFrame{df, dfb} {
+		for _, u := range t.Names() {
+			if _, ok := uniques[u]; !ok {
+				uniques[u] = struct{}{}
+				cols = append(cols, u)
+			}
+		}
+	}
+
+	expandedSeries := make([]series.Series, len(cols))
+	for k, v := range cols {
+		aidx := findInStringSlice(v, df.Names())
+		bidx := findInStringSlice(v, dfb.Names())
+
+		// aidx and bidx must not be -1 at the same time.
+		var a, b series.Series
+		if aidx != -1 {
+			a = df.columns[aidx]
+		} else {
+			bb := dfb.columns[bidx]
+			a = series.New(make([]struct{}, df.nrows), bb.Type(), bb.Name)
+		}
+		if bidx != -1 {
+			b = dfb.columns[bidx]
+		} else {
+			b = series.New(make([]struct{}, dfb.nrows), a.Type(), a.Name)
+		}
+		newSeries := a.Concat(b)
+		if err := newSeries.Err; err != nil {
+			return DataFrame{Err: fmt.Errorf("concat: %v", err)}
+		}
+		expandedSeries[k] = newSeries
+	}
+	return New(expandedSeries...)
+}
+
 // Mutate changes a column of the DataFrame with the given Series or adds it as
 // a new column if the column name does not exist.
 func (df DataFrame) Mutate(s series.Series) DataFrame {

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -553,6 +553,117 @@ func TestDataFrame_RBind(t *testing.T) {
 	}
 }
 
+func TestDataFrame_Concat(t *testing.T) {
+	type NA struct{}
+
+	a := New(
+		series.New([]string{"b", "a", "b", "c", "d"}, series.String, "COL.1"),
+		series.New([]int{1, 2, 4, 5, 4}, series.Int, "COL.2"),
+		series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+	)
+	table := []struct {
+		dfa   DataFrame
+		dfb   DataFrame
+		expDf DataFrame
+	}{
+		{
+			a,
+			New(
+				series.New([]string{"b", "a", "b", "c", "d"}, series.String, "COL.1"),
+				series.New([]int{1, 2, 4, 5, 4}, series.Int, "COL.2"),
+				series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+			),
+			New(
+				series.New([]string{"b", "a", "b", "c", "d", "b", "a", "b", "c", "d"}, series.String, "COL.1"),
+				series.New([]int{1, 2, 4, 5, 4, 1, 2, 4, 5, 4}, series.Int, "COL.2"),
+				series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2, 3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+			),
+		},
+		{
+			a,
+			New(
+				series.New([]int{1, 2, 4, 5, 4}, series.Int, "COL.1"),
+				series.New([]int{1, 2, 4, 5, 4}, series.Int, "COL.2"),
+				series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+			),
+			New(
+				series.New([]string{"b", "a", "b", "c", "d", "1", "2", "4", "5", "4"}, series.String, "COL.1"),
+				series.New([]int{1, 2, 4, 5, 4, 1, 2, 4, 5, 4}, series.Int, "COL.2"),
+				series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2, 3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+			),
+		},
+
+		{
+			a,
+			New(
+				series.New([]string{"b", "a", "b", "c", "d"}, series.String, "COL.1"),
+				series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+			),
+			New(
+				series.New([]string{"b", "a", "b", "c", "d", "b", "a", "b", "c", "d"}, series.String, "COL.1"),
+				series.New([]int{1, 2, 4, 5, 4}, series.Int, "COL.2").Concat(series.New([]NA{NA{}, NA{}, NA{}, NA{}, NA{}}, series.Int, "")),
+				series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2, 3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+			),
+		},
+		{
+			a,
+			New(
+				series.New([]int{1, 2, 4, 5, 4}, series.Int, "COL.1"),
+				series.New([]int{1, 2, 4, 5, 4}, series.Int, "COL.2"),
+				series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+				series.New([]string{"a", "b", "c", "d", "e"}, series.String, "COL.4"),
+			),
+			New(
+				series.New([]string{"b", "a", "b", "c", "d", "1", "2", "4", "5", "4"}, series.String, "COL.1"),
+				series.New([]int{1, 2, 4, 5, 4, 1, 2, 4, 5, 4}, series.Int, "COL.2"),
+				series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2, 3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+				series.New([]NA{NA{}, NA{}, NA{}, NA{}, NA{}}, series.String, "COL.4").Concat(series.New([]string{"a", "b", "c", "d", "e"}, series.String, "COL.4")),
+			),
+		},
+		{
+			a,
+			New(
+				series.New([]string{"a", "b", "c", "d", "e"}, series.String, "COL.0"),
+				series.New([]int{1, 2, 4, 5, 4}, series.Int, "COL.1"),
+				series.New([]int{1, 2, 4, 5, 4}, series.Int, "COL.2"),
+				series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+			),
+			New(
+				series.New([]string{"b", "a", "b", "c", "d", "1", "2", "4", "5", "4"}, series.String, "COL.1"),
+				series.New([]int{1, 2, 4, 5, 4, 1, 2, 4, 5, 4}, series.Int, "COL.2"),
+				series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2, 3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+				series.New([]NA{NA{}, NA{}, NA{}, NA{}, NA{}}, series.String, "COL.0").Concat(series.New([]string{"a", "b", "c", "d", "e"}, series.String, "COL.0")),
+			),
+		},
+		{
+			DataFrame{},
+			a,
+			a,
+		},
+	}
+	for i, tc := range table {
+		b := tc.dfa.Concat(tc.dfb)
+
+		if b.Err != nil {
+			t.Errorf("Test: %d\nError:%v", i, b.Err)
+		}
+		//if err := checkAddrDf(a, b); err != nil {
+		//t.Error(err)
+		//}
+		// Check that the types are the same between both DataFrames
+		if !reflect.DeepEqual(tc.expDf.Types(), b.Types()) {
+			t.Errorf("Test: %d\nDifferent types:\nA:%v\nB:%v", i, tc.expDf.Types(), b.Types())
+		}
+		// Check that the colnames are the same between both DataFrames
+		if !reflect.DeepEqual(tc.expDf.Names(), b.Names()) {
+			t.Errorf("Test: %d\nDifferent colnames:\nA:%v\nB:%v", i, tc.expDf.Names(), b.Names())
+		}
+		// Check that the values are the same between both DataFrames
+		if !reflect.DeepEqual(tc.expDf.Records(), b.Records()) {
+			t.Errorf("Test: %d\nDifferent values:\nA:%v\nB:%v", i, tc.expDf.Records(), b.Records())
+		}
+	}
+}
 func TestDataFrame_Records(t *testing.T) {
 	a := New(
 		series.New([]string{"a", "b", "c"}, series.String, "COL.1"),


### PR DESCRIPTION
Concat concatenates rows of two dataframes like RBind, but also
includes the unmatched columns.