### PR TITLE
Use UseNumber() when parsing JSON to interface{}

### DIFF
--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -1106,7 +1106,9 @@ func ReadCSV(r io.Reader, options ...LoadOption) DataFrame {
 // resulting records.
 func ReadJSON(r io.Reader, options ...LoadOption) DataFrame {
 	var m []map[string]interface{}
-	err := json.NewDecoder(r).Decode(&m)
+	d:=json.NewDecoder(r)
+	d.UseNumber()
+	err := d.Decode(&m)
 	if err != nil {
 		return DataFrame{Err: err}
 	}

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -1191,13 +1191,13 @@ func TestReadJSON(t *testing.T) {
 		expDf   DataFrame
 	}{
 		{
-			`[{"COL.1":null,"COL.2":1,"COL.3":3},{"COL.1":5,"COL.2":2,"COL.3":2},{"COL.1":6,"COL.2":3,"COL.3":1}]`,
+			`[{"COL.1":null,"COL.2":1,"COL.3":3},{"COL.1":5,"COL.2":2,"COL.3":2},{"COL.1":6,"COL.2":3,"COL.3":20180428}]`,
 			LoadRecords(
 				[][]string{
 					{"COL.1", "COL.2", "COL.3"},
 					{"NaN", "1", "3"},
 					{"5", "2", "2"},
-					{"6", "3", "1"},
+					{"6", "3", "20180428"},
 				},
 				DetectTypes(false),
 				DefaultType(series.Int),


### PR DESCRIPTION
This solves the issue #66  

Document for UseNumber: https://golang.org/pkg/encoding/json/#Decoder.UseNumber
Stackoveflow: https://stackoverflow.com/a/22346593/6109457

Code Run:
```
jsonstr:= `[{"COL.1":null,"COL.2":1,"COL.3":3},{"COL.1":5,"COL.2":2,"COL.3":2},{"COL.1":6,"COL.2":3,"COL.3":20180428}]`
c := dataframe.ReadJSON(strings.NewReader(jsonstr))
fmt.Println(c)
```
Before:
```
    COL.1 COL.2 COL.3          
 0: NaN   1     3.000000       
 1: 5     2     2.000000       
 2: 6     3     20180428.000000
    <int> <int> <float>    
```

After:
```
    COL.1 COL.2 COL.3   
 0: NaN   1     3       
 1: 5     2     2       
 2: 6     3     20180428
    <int> <int> <int>   
```