### PR TITLE
AddConstant

### DIFF
--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"reflect"
 	"sort"
 	"strconv"
@@ -1970,4 +1971,31 @@ func (df DataFrame) Describe() DataFrame {
 
 	ddf := New(ss...)
 	return ddf
+}
+
+// AddConstant returns new dataframe with new column
+// having constant value with given column name
+func (df DataFrame) AddConstant(value interface{}, colName string) DataFrame {
+
+	var typeOfSeries series.Type
+	switch value.(type) {
+	case int:
+		typeOfSeries = series.Int
+	case float64:
+		typeOfSeries = series.Float
+	case string:
+		typeOfSeries = series.String
+	case bool:
+		typeOfSeries = series.Bool
+	default:
+		log.Fatalln("Unsupported series type")
+	}
+
+	constSlice := make([]interface{}, df.Nrow())
+	for i := range constSlice {
+		constSlice[i] = value
+	}
+
+	constSeries := series.New(constSlice, typeOfSeries, colName)
+	return df.Mutate(constSeries)
 }

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -2,6 +2,7 @@ package dataframe
 
 import (
 	"bytes"
+	"math/rand"
 	"reflect"
 	"strconv"
 	"strings"
@@ -68,6 +69,29 @@ func TestDataFrame_Copy(t *testing.T) {
 	}
 }
 
+func TestAddConstant(t *testing.T) {
+	a := New(
+		series.New([]string{"b", "a", "b", "c", "d"}, series.String, "COL.1"),
+		series.New([]int{1, 2, 4, 5, 4}, series.Int, "COL.2"),
+		series.New([]float64{3.0, 4.0, 5.3, 3.2, 1.2}, series.Float, "COL.3"),
+	)
+	b := a.AddConstant(20, "f")
+
+	colF := b.Col("f")
+	if colF.Err != nil {
+		t.Errorf("Test: AddConstant %v", colF.Err.Error())
+	} else if len(b.columns) != 4 {
+		t.Errorf("Test: AddConstant %v", "column not added to dataframe")
+	} else if colF.Type() != "int" {
+		t.Errorf("Test: AddConstant %v", "wrong column type")
+	} else if colF.Len() != a.Nrow() {
+		t.Errorf("Test: AddConstant %v", "serise lenght not matching")
+	} else if a, _ := colF.Elem(rand.Intn(a.Nrow())).Int(); a != 20 {
+		// As column type check has passed return will be integer
+		// so, we are only checking for the value and error is ignored
+		t.Errorf("Test: AddConstant %v", "values not same for all elements.")
+	}
+}
 func TestDataFrame_Subset(t *testing.T) {
 	a := New(
 		series.New([]string{"b", "a", "b", "c", "d"}, series.String, "COL.1"),


### PR DESCRIPTION
AddConstant function adds new named column to dataframe with provided constant value.

For example,
a = a.AddConstant(20, "f")
adds column f with constant value 20
```
|  x1 |  f  |
- - - - - - -
|  1  |  20 |
|  2  |  20 |
```