### PR TITLE
Series.Mean() will return Expected value by ignoring NaN values.

### DIFF
--- a/series/series_test.go
+++ b/series/series_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"testing"
 	"strings"
+	"testing"
 )
 
 // Check that there are no shared memory addreses between the elements of two Series
@@ -1232,6 +1232,10 @@ func TestSeries_Mean(t *testing.T) {
 			2.0,
 		},
 		{
+			NewFloats([]float64{1.0, 2.0, 3.0, math.NaN()}),
+			2.0,
+		},
+		{
 			Strings([]string{"A", "B", "C", "D"}),
 			math.NaN(),
 		},
@@ -1525,9 +1529,8 @@ func TestSeries_Quantile(t *testing.T) {
 	}
 }
 
-
 func TestSeries_Map(t *testing.T) {
-		tests := []struct {
+	tests := []struct {
 		series   Series
 		expected Series
 	}{
@@ -1564,11 +1567,11 @@ func TestSeries_Map(t *testing.T) {
 	doubleFloat64 := func(e Element) Element {
 		var result Element
 		result = e.Copy()
-		result.Set(result.Float() * 2)		
+		result.Set(result.Float() * 2)
 		return Element(result)
 	}
 
-	// and two booleans 
+	// and two booleans
 	and := func(e Element) Element {
 		var result Element
 		result = e.Copy()
@@ -1588,11 +1591,11 @@ func TestSeries_Map(t *testing.T) {
 		i, err := result.Int()
 		if err != nil {
 			return Element(&intElement{
-				e: +5,
+				e:   +5,
 				nan: false,
 			})
 		}
-		result.Set(i + 5)		
+		result.Set(i + 5)
 		return Element(result)
 	}
 
@@ -1604,12 +1607,12 @@ func TestSeries_Map(t *testing.T) {
 		return Element(result)
 	}
 
-		for testnum, test := range tests {
+	for testnum, test := range tests {
 		switch test.series.Type() {
 		case Bool:
 			expected := test.expected
 			received := test.series.Map(and)
-			for i := 0 ; i<expected.Len() ; i++ {
+			for i := 0; i < expected.Len(); i++ {
 				e, _ := expected.Elem(i).Bool()
 				r, _ := received.Elem(i).Bool()
 
@@ -1620,13 +1623,13 @@ func TestSeries_Map(t *testing.T) {
 					)
 				}
 			}
-			
+
 		case Float:
 			expected := test.expected
 			received := test.series.Map(doubleFloat64)
-			for i := 0 ; i<expected.Len() ; i++ {
+			for i := 0; i < expected.Len(); i++ {
 				if !compareFloats(expected.Elem(i).Float(),
-				received.Elem(i).Float(), 6) {
+					received.Elem(i).Float(), 6) {
 					t.Errorf(
 						"Test:%v\nExpected:\n%v\nReceived:\n%v",
 						testnum, expected, received,
@@ -1636,7 +1639,7 @@ func TestSeries_Map(t *testing.T) {
 		case Int:
 			expected := test.expected
 			received := test.series.Map(add5Int)
-			for i := 0 ; i<expected.Len() ; i++ {
+			for i := 0; i < expected.Len(); i++ {
 				e, _ := expected.Elem(i).Int()
 				r, _ := received.Elem(i).Int()
 				if e != r {
@@ -1649,9 +1652,9 @@ func TestSeries_Map(t *testing.T) {
 		case String:
 			expected := test.expected
 			received := test.series.Map(trimXyZPrefix)
-			for i :=0 ; i<expected.Len() ; i++ {
+			for i := 0; i < expected.Len(); i++ {
 				if strings.Compare(expected.Elem(i).String(),
-				received.Elem(i).String()) != 0 {
+					received.Elem(i).String()) != 0 {
 					t.Errorf(
 						"Test:%v\nExpected:\n%v\nReceived:\n%v",
 						testnum, expected, received,


### PR DESCRIPTION
The users can use new method called **NewSeries()** to initialise Series with **IsNaNToBeIgnore** option to ignore NaN values for aggregate operations. For example
`NewFloats([]float64{1.0, 2.0, 3.0, math.NaN()})`. The aggregate functions will ignore the 3rd index by default. 
