### PR TITLE
changing float to string precision

### DIFF
--- a/series/type-float.go
+++ b/series/type-float.go
@@ -74,7 +74,7 @@ func (e floatElement) String() string {
 	if e.IsNA() {
 		return "NaN"
 	}
-	return fmt.Sprintf("%f", e.e)
+	return fmt.Sprintf("%g", e.e)
 }
 
 func (e floatElement) Int() (int, error) {


### PR DESCRIPTION
Function `fmt.Sprintf("%f", some_float_number)` converts float to string with a default precision equal to 6:
`The default precision for %e, %f and %#g is 6; for %g it is the smallest number of digits necessary to identify the value uniquely.`
 ([source](https://golang.org/pkg/fmt/ )).
 Changing format from "%f" to "%g" gives a precision necessary for saving floating point numbers without loss.