### PR TITLE
Make series.Order stable

### DIFF
--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -2423,6 +2423,58 @@ func TestDataFrame_Arrange(t *testing.T) {
 	}
 }
 
+func TestDataFrame_Arrange2(t *testing.T) {
+	table := []struct {
+		df       DataFrame
+		colnames []Order
+		expDf    DataFrame
+	}{
+		{
+			New(
+				series.New([]string{"A", "C", "B", "D", "C", "A", "D", "B"}, series.String, "A"),
+				series.New([]string{"103", "103", "103", "103", "100", "100", "100", "100"}, series.Int, "B"),
+			),
+			[]Order{Sort("B")},
+			New(
+				series.New([]string{"C", "A", "D", "B", "A", "C", "B", "D"}, series.String, "A"),
+				series.New([]string{"100", "100", "100", "100", "103", "103", "103", "103"}, series.Int, "B"),
+			),
+		},
+		{
+			New(
+				series.New([]string{"A", "C", "B", "D", "C", "A", "D", "B"}, series.String, "A"),
+				series.New([]string{"103", "103", "103", "103", "100", "100", "100", "100"}, series.Int, "B"),
+			),
+			[]Order{Sort("A"), Sort("B")},
+			New(
+				series.New([]string{"A", "A", "B", "B", "C", "C", "D", "D"}, series.String, "A"),
+				series.New([]string{"100", "103", "100", "103", "100", "103", "100", "103"}, series.Int, "B"),
+			),
+		},
+	}
+	for i, tc := range table {
+		b := tc.df.Arrange(tc.colnames...)
+
+		if b.Err != nil {
+			t.Errorf("Test: %d\nError:%v", i, b.Err)
+		}
+		// Check that the types are the same between both DataFrames
+		if !reflect.DeepEqual(tc.expDf.Types(), b.Types()) {
+			t.Errorf("Test: %d\nDifferent types:\nExpected:%v\nRecieved:%v", i, tc.expDf.Types(), b.Types())
+		}
+		// Check that the colnames are the same between both DataFrames
+		if !reflect.DeepEqual(tc.expDf.Names(), b.Names()) {
+			t.Errorf("Test: %d\nDifferent colnames:\nExpected:%v\nRecieved:%v", i, tc.expDf.Names(), b.Names())
+		}
+		// Check that the values are the same between both DataFrames
+		tcr := tc.expDf.Records()
+		br := b.Records()
+		if !reflect.DeepEqual(tcr, br) {
+			t.Errorf("Test: %d\nDifferent values:\nExpected:%v\nRecieved:%v", i, tcr, br)
+		}
+	}
+}
+
 func TestDataFrame_Capply(t *testing.T) {
 	a := LoadRecords(
 		[][]string{

--- a/series/series.go
+++ b/series/series.go
@@ -655,7 +655,7 @@ func (s Series) Order(reverse bool) []int {
 	if reverse {
 		srt = sort.Reverse(srt)
 	}
-	sort.Sort(srt)
+	sort.Stable(srt)
 	var ret []int
 	for _, e := range ie {
 		ret = append(ret, e.index)


### PR DESCRIPTION
series.Order does not use the stable sort, this results in DataFrames with multiple columns returning unexpected results. Specifically, the outcome is not what is seen in R or Python (Pandas) and presented me with a hard to find bug in my Go code.

For example:

```python
>>> import pandas as pd
>>> 
>>> data = {'A': ["A", "C", "B", "D", "C", "A", "D", "B"], 
...     'B': [103, 103, 103, 103, 100, 100, 100, 100]}
>>> df = pd.DataFrame.from_dict(data)
>>> df
   A    B
0  A  103
1  C  103
2  B  103
3  D  103
4  C  100
5  A  100
6  D  100
7  B  100
>>> df.sort_values(by=['B'])
   A    B
4  C  100
5  A  100
6  D  100
7  B  100
0  A  103
1  C  103
2  B  103
3  D  103
>>> df.sort_values(by=['A','B'])
   A    B
5  A  100
0  A  103
7  B  100
2  B  103
4  C  100
1  C  103
6  D  100
3  D  103
>>> 
```

I've included a new test that exposes this issue and a simple fix.