### PR TITLE
Trim the spaces when getting the list of column names

### DIFF
--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -1214,7 +1214,9 @@ func LoadRecords(records [][]string, options ...LoadOption) DataFrame {
 	// Extract headers
 	headers := make([]string, len(records[0]))
 	if cfg.hasHeader {
-		headers = records[0]
+		for i, colname := range records[0] {
+			headers[i] = strings.TrimSpace(colname)
+		}
 		records = records[1:]
 	}
 	if cfg.names != nil {

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -1214,6 +1214,23 @@ func TestLoadRecords(t *testing.T) {
 			),
 			false,
 		},
+		{ //Test 16. Test for trimming whitespace when getting a list of column names
+			LoadRecords(
+				[][]string{
+					{"A A", " B B", " C ", " D D "},
+					{"5.1", "3.5", "1.4", "0.2"},
+					{"1", "1", "true", "0.5"},
+					{"1", "2", "0.5", "a"},
+				},
+			),
+			New(
+				series.New([]float64{5.1, 1, 1}, series.Float, "A A"),
+				series.New([]float64{3.5, 1, 2}, series.Float, "B B"),
+				series.New([]string{"1.4", "true", "NaN"}, series.Bool, "C"),
+				series.New([]string{"0.2", "0.5", "a"}, series.String, "D D"),
+			),
+			false,
+		},
 	}
 
 	for i, tc := range table {


### PR DESCRIPTION
Bug fix for [issues #173](https://github.com/go-gota/gota/issues/173#issue-1046806796). We now trim the spaces when getting the list of column names. I also added a test for this fix.